### PR TITLE
Limit contacts used in loop to 200

### DIFF
--- a/force-app/main/default/classes/PerformLoopLocalVariableSingleUse.cls
+++ b/force-app/main/default/classes/PerformLoopLocalVariableSingleUse.cls
@@ -26,11 +26,20 @@ public with sharing class PerformLoopLocalVariableSingleUse
             LIMIT :numberOfAccounts
         ]);
 
+        System.assertEquals(
+            numberOfAccounts,
+            accountMap.size(),
+            'accountMap size'
+        );
+
         List<Contact> contactList = [
             SELECT Id, AccountId, OwnerId
             FROM Contact
             WHERE AccountId IN :accountMap.keySet()
+            LIMIT 200
         ];
+
+        System.assertEquals(200, contactList.size(), 'contactList size');
 
         // Note the start time
         Datetime startDatetime = Datetime.now();

--- a/force-app/main/default/classes/PerformLoopMapItemSingleUse.cls
+++ b/force-app/main/default/classes/PerformLoopMapItemSingleUse.cls
@@ -29,11 +29,20 @@ public with sharing class PerformLoopMapItemSingleUse
             LIMIT :numberOfAccounts
         ]);
 
+        System.assertEquals(
+            numberOfAccounts,
+            accountMap.size(),
+            'accountMap size'
+        );
+
         List<Contact> contactList = [
             SELECT Id, AccountId, OwnerId
             FROM Contact
             WHERE AccountId IN :accountMap.keySet()
+            LIMIT 200
         ];
+
+        System.assertEquals(200, contactList.size(), 'contactList size');
 
         // Note the start time
         Datetime startDatetime = Datetime.now();


### PR DESCRIPTION
This pr fixes a bug from #3 with the number of contacts tested being variable, potentially exceeding the expected number of 200 (max size of a batch processed in single transaction context).